### PR TITLE
add more communication examples and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,169 @@
+# Revieve WKWebView Integration Sample
+
+This repository contains a sample iOS application that demonstrates how to integrate our plugin solution within a native app using WKWebView. The primary goal of this sample project is to provide developers with a clear and concise guide for integrating our plugin with their native applications.
+
+## Table of Contents
+
+1. [Getting Started](#getting-started)
+2. [Integration Steps](#integration-steps)
+3. [Communication with plugin](#communication-with-plugin)
+
+## Getting Started
+
+Before you begin, make sure you have the following prerequisites:
+
+- Xcode installed on your development machine.
+- An iOS device or simulator.
+- A partnerId provided by Revieve.
+
+Clone the repository and open the project in Xcode:
+
+```bash
+git clone https://github.com/revieve/revieve-plugin-wkwebview-sample.git
+cd revieve-plugin-wkwebview-sample
+open revieve-plugin-wkwebview-sample.xcodeproj
+```
+
+## Integration Steps
+
+Follow these step-by-step instructions to integrate the plugin solution within your iOS application using WKWebView:
+
+1. **Configure partnerId and environment:**
+
+In your `ViewController.swift` file, setup the configuration variables as instructed by our implementation team:
+
+```swift
+  // Select which Revieve API environment to use. Can be test or prod
+static let ENV = "test"
+// your partner Id provided by Revieve
+static let PARTNER_ID = "GHru81v4aU"
+```
+
+2. **Configure the WKWebView:**
+
+Set up a `WKWebViewConfiguration` instance, configure it with necessary settings, and create a `WKWebView` instance using the configuration:
+
+```swift
+let webConfiguration = WKWebViewConfiguration()
+webConfiguration.allowsInlineMediaPlayback = true
+webView = WKWebView(frame: .zero, configuration: webConfiguration)
+webView.uiDelegate = self
+```
+
+3. **Inject JavaScript:**
+
+Add a JavaScript code snippet to your `WKWebViewConfiguration` instance that defines a custom `postMessage` function. This function will forward the received messages to your native app:
+
+```swift
+let js = """
+(function() {
+    window.parent = {
+        postMessage: function(data, target) {
+            if (target !== "\(Revieve.ORIGIN)" && target !== "\(Revieve.CDN_DOMAIN)") return;
+            if (data === undefined || data === "undefined") return;
+            var dataNormalized = typeof data === "object" ? JSON.stringify(data) : data.toSring();
+            if (window.webkit.messageHandlers.revieveMessageHandler) window.webkit.messageHandlers.revieveMessageHandler.postMessage(dataNormalized);
+        }
+    }
+    true;
+})()
+```
+
+4. **Handle JavaScript messages:**
+
+Conform your view controller to the `WKScriptMessageHandler` protocol and implement the `userContentController(_:didReceive:)` method to handle messages from the plugin:
+
+```swift
+extension ViewController: WKScriptMessageHandler {
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    // Handle JavaScript messages here
+  }
+}
+```
+
+5. **Load the plugin:**
+
+Create a `URLRequest` using the plugin solution's CDN URL and partner ID, and load it into the WKWebView instance:
+
+```swift
+  let request = URLRequest(url: pluginURL)
+  webView.load(request)
+```
+
+6. **Add the WKWebView to your view hierarchy:**
+
+Add the `WKWebView` instance to your view controller's view hierarchy:
+
+```swift
+  view.addSubview(webView)
+```
+
+## Communication with plugin
+
+The sample project provides a basic integration with the plugin solution. You should customize custom behavior in response to plugin events by modifying the source code as needed.
+
+Refer to the plugin solution's basic and advanced documentation for details on available callbacks and data options.
+
+The `postMessage` API enables seamless communication between the plugin solution and your native application. This section will guide you through the process of setting up and handling `postMessage` communication in the WKWebView integration sample.
+
+### Handling PostMessage Events
+
+Implement the `userContentController(_:didReceive:)` method in your view controller to handle incoming `postMessage` events:
+
+```swift
+extension ViewController: WKScriptMessageHandler {
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    // Handle JavaScript messages here
+  }
+}
+```
+
+Inside the `userContentController(_:didReceive:)` method, you can parse the JSON message body and perform actions based on the received events. For example, you may want to display an alert when a specific event is triggered:
+
+```swift
+func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+  if let body = message.body as? String {
+    handleMessage(body)
+  }
+}
+
+func handleMessage(_ body: String) {
+  // Parse and handle the message here
+  // ...
+  if type == "someEventType" {
+    showAlert(title: "Event triggered", message: "The 'someEventType' event has been triggered")
+  }
+}
+```
+
+Refer to the plugin solution's documentation for a comprehensive list of available events and their payloads.
+
+### Sending PostMessage Commands
+
+In some cases like PDP try-on integration you may want to send commands from your native app to the  plugin. This section will demonstrate how to send a command to the plugin using `postMessage` communication.
+
+1. **Create a function to send the command:**
+
+For example, let's say you want to send a `tryonProduct` command with a specific product ID when a button is clicked.
+
+```swift
+@objc func pdpButtonClicked() {
+  let productId = "02762"
+  let action = "{\"type\":\"tryonProduct\", \"payload\": {\"id\":\"\(productId)\"}}"
+  webView.evaluateJavaScript("window.postMessage(\(action), '*')", completionHandler: nil)
+}
+```
+
+In the example above, a JSON object is created with the appropriate `type` and `payload`. This JSON object is then sent to the WebView plugin using the `evaluateJavaScript` method.
+
+2. **Add a button to trigger the command:**
+
+Add a UIButton to your app's user interface that triggers the `pdpButtonClicked` function when clicked. Don't forget to add the following line in the button setup to connect the button to the `pdpButtonClicked` function:
+
+```swift
+  pdpButton.addTarget(self, action: #selector(pdpButtonClicked), for: .touchUpInside)
+```
+
+In the source code you can set Revieve.SHOW_PDP_BUTTON to `true` to see a demo implementation of the PDP button communication.
+
+By following these steps, you can enable two-ways communication between your app and the plugin.

--- a/revieve-plugin-wkwebview-sample/ViewController.swift
+++ b/revieve-plugin-wkwebview-sample/ViewController.swift
@@ -13,27 +13,85 @@
 import UIKit
 import WebKit
 
-// Load the revieve-web-plugin from Revieve's production CDN:
-let REVIEVE_CDN_DOMAIN = "https://d38knilzwtuys1.cloudfront.net"
-// Origin set to *
-let REVIEVE_ORIGIN = "*"
-// Select which Revieve API environment to use. Can be test or prod
-let REVIEVE_ENV = "test"
-// Partner ID
-let REVIEVE_PARTNER_ID = "9KpsLizwYK" // skincare demo
-// let REVIEVE_PARTNER_ID = "TShEWzW05I" // vto makeup demo
-
-// Construct the full URL
-let REVIEVE_FULL_URL = URL(string:"\(REVIEVE_CDN_DOMAIN)/revieve-plugin-v4/app.html?partnerId=\(REVIEVE_PARTNER_ID)&env=\(REVIEVE_ENV)&crossOrigin=1&origin=\(REVIEVE_ORIGIN)")
-
+struct Revieve {
+    // Load the revieve-web-plugin from Revieve's production CDN:
+    static let CDN_DOMAIN = "https://d38knilzwtuys1.cloudfront.net"
+    // Origin set to *
+    static let ORIGIN = "*"
+    // Select which Revieve API environment to use. Can be test or prod
+    static let ENV = "test"
+    // static let PARTNER_ID = "9KpsLizwYK" // skincare demo
+    static let PARTNER_ID = "GHru81v4aU" // vto makeup demo
+    // PDP VTO trigger example
+    static let SHOW_PDP_BUTTON = false
+    // Construct the full URL
+    static let FULL_URL = URL(string: "\(CDN_DOMAIN)/revieve-plugin-v4/app.html?partnerId=\(PARTNER_ID)&env=\(ENV)&crossOrigin=1&origin=\(ORIGIN)")
+}
 
 class ViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler {
     var webView: WKWebView!
     
+    func showAlert(title: String, message: String) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        
+        let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        alertController.addAction(okAction)
+        
+        self.present(alertController, animated: true, completion: nil)
+    }
+    
+    func handleMessage(_ body: String) {
+        if let data = body.data(using: .utf8) {
+            do {
+                if let message = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+                    handleJSONMessage(message)
+                }
+            } catch {
+                // Handle JSON parsing exception
+                print("Error parsing JSON: \(error)")
+            }
+        }
+    }
+    
+    func handleJSONMessage(_ message: [String: Any]) {
+        guard let type = message["type"] as? String else {
+            return
+        }
+
+        // callback message handling examples
+        if type == "onClose" { 
+            showAlert(title: type, message: "User clicked close button")
+        } else if type == "onClickProduct" {
+            handleOnClickProduct(message: message)
+        }
+    }
+
+    func handleOnClickProduct(message: [String: Any]) {
+        guard let payloadArray = message["payload"] as? [[String: Any]], !payloadArray.isEmpty else {
+            return
+        }
+
+        let payload = payloadArray[0]
+        
+        guard let url = payload["url"] as? String, let productId = payload["id"] as? String else {
+            return
+        }
+
+        let title = "User clicked product"
+        let description = "id: \(productId)\nurl: \(url)"
+        
+        DispatchQueue.main.async { [weak self] in
+            self?.showAlert(title: title, message: description)
+        }
+    }
+
     // All the revieve-web-plugin events arrive here and can be used in the native app as you see fit
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         print("Received a message from the revieve plugin:")
         print(message.body)
+        if let body = message.body as? String {
+            handleMessage(body)
+        }
     }
 
     override func loadView() {
@@ -42,7 +100,7 @@ class ViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler {
                 (function() {
                     window.parent = {
                         postMessage: function(data, target) {
-                            if (target !== "\(REVIEVE_ORIGIN)" && target !== "\(REVIEVE_CDN_DOMAIN)") return;
+                            if (target !== "\(Revieve.ORIGIN)" && target !== "\(Revieve.CDN_DOMAIN)") return;
                             if (data === undefined || data === "undefined") return;
                             var dataNormalized = typeof data === "object" ? JSON.stringify(data) : data.toSring();
                             if (window.webkit.messageHandlers.revieveMessageHandler) window.webkit.messageHandlers.revieveMessageHandler.postMessage(dataNormalized);
@@ -63,11 +121,49 @@ class ViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler {
         webView.uiDelegate = self
 
         view = webView
+
+        // Set up a demo PDP button
+        if (Revieve.SHOW_PDP_BUTTON) {
+            setupPDPButton()
+        }
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        webView.load(URLRequest(url: REVIEVE_FULL_URL!))
+        webView.load(URLRequest(url: Revieve.FULL_URL!))
     }
 
+    func setupPDPButton() {
+        let pdpButton = UIButton(type: .system)
+        pdpButton.addTarget(self, action: #selector(pdpButtonClicked), for: .touchUpInside)
+        pdpButton.translatesAutoresizingMaskIntoConstraints = false
+        pdpButton.setImage(UIImage(systemName: "mouth.fill"), for: .normal)
+        pdpButton.tintColor = .red
+        pdpButton.backgroundColor = .white // Set background color
+        pdpButton.layer.cornerRadius = 8
+        view.addSubview(pdpButton)
+
+        let minHeight: CGFloat = 44
+        let minWidth: CGFloat = 44
+        let buttonSize = pdpButton.intrinsicContentSize
+        let verticalPadding = max((minHeight - buttonSize.height) / 2, 0)
+        let horizontalPadding = max((minWidth - buttonSize.width) / 2, 0)
+        pdpButton.contentEdgeInsets = UIEdgeInsets(top: verticalPadding, left: horizontalPadding, bottom: verticalPadding, right: horizontalPadding)
+
+        view.addSubview(pdpButton)
+
+        let padding: CGFloat = 16
+
+        NSLayoutConstraint.activate([
+            pdpButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -padding),
+            pdpButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -padding),
+        ])
+
+    } 
+
+    @objc func pdpButtonClicked() {
+        let productId = "02762"
+        let action = "{\"type\":\"tryonProduct\", \"payload\": {\"id\":\"\(productId)\"}}"
+        webView.evaluateJavaScript("window.postMessage(\(action), '*')", completionHandler: nil)
+    }
 }


### PR DESCRIPTION
This PR adds more examples of communication:
- handling incoming events through postMessage (onClose, onProductClick)
- sending commands to plugin (tryOnProduct for PDP VTO integration)
Also added a readme to make the intent and the purpose of the code more clear to anyone interacting with it